### PR TITLE
Replace set-output with GITHUB_OUTPUT

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -50,7 +50,7 @@ runs:
         trap 'echo "::remove-matcher owner=freckle-weeder::"' EXIT
 
         tmp=$(mktemp)
-        echo "::set-output name=log::$tmp"
+        echo "log=$tmp" >>"$GITHUB_OUTPUT"
 
         cd '${{ inputs.working-directory }}'
         prefix=$(echo '${{ inputs.working-directory }}' | sed 's|/$||')/


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
