### PR TITLE
Build and utilize pre-compiled binaries

### DIFF
--- a/.github/bin/build-binaries-matrix
+++ b/.github/bin/build-binaries-matrix
@@ -46,7 +46,7 @@ Asset = Struct.new(:ghc, :os) do
     when "darwin"
       { runner: "macOS-latest", ext: "tar.gz", zip: "tar -czf" }
     when "win32"
-      { runner: "windows-latest", ext: "7z", zip: 'C:\Program Files\7-Zip\7z.exe' }
+      { runner: "windows-latest", ext: "7z", zip: '"C:\Program Files\7-Zip\7z.exe"' }
     else
       raise "Unexpected OS: #{os}, must be linux|darwin|win32"
     end

--- a/.github/bin/build-binaries-matrix
+++ b/.github/bin/build-binaries-matrix
@@ -46,7 +46,7 @@ Asset = Struct.new(:ghc, :os) do
     when "darwin"
       { runner: "macOS-latest", ext: "tar.gz", zip: "tar -czf" }
     when "win32"
-      { runner: "windows-latest", ext: "zip", zip: "zip" }
+      { runner: "windows-latest", ext: "zip", zip: 'C:\Program Files\7-Zip\7z.exe' }
     else
       raise "Unexpected OS: #{os}, must be linux|darwin|win32"
     end

--- a/.github/bin/build-binaries-matrix
+++ b/.github/bin/build-binaries-matrix
@@ -46,7 +46,7 @@ Asset = Struct.new(:ghc, :os) do
     when "darwin"
       { runner: "macOS-latest", ext: "tar.gz", zip: "tar -czf" }
     when "win32"
-      { runner: "windows-latest", ext: "7z", zip: '"C:\Program Files\7-Zip\7z.exe"' }
+      { runner: "windows-latest", ext: "zip", zip: '"C:\Program Files\7-Zip\7z.exe" a -tzip' }
     else
       raise "Unexpected OS: #{os}, must be linux|darwin|win32"
     end

--- a/.github/bin/build-binaries-matrix
+++ b/.github/bin/build-binaries-matrix
@@ -1,0 +1,112 @@
+#!/usr/bin/env ruby
+require "json"
+
+RELEASE_NAME = "Binaries"
+
+EXISTING_ASSETS = JSON.parse(`
+  gh --repo freckle/weeder-action release view #{RELEASE_NAME} --json assets |
+    jq '.assets | map(.name)'
+`)
+
+GHCs = %W[
+  9.2.5
+  9.2.4
+  9.2.3
+  9.2.2
+  9.0.2
+  9.0.1
+  8.10.7
+  8.10.6
+  8.10.5
+  8.10.4
+  8.10.3
+  8.10.2
+  8.10.1
+  8.8.4
+  8.8.3
+  8.8.2
+  8.8.1
+]
+
+Asset = Struct.new(:ghc, :os) do
+  def name
+    "weeder-#{ghc}-#{os}-x64.#{os_attributes.fetch(:ext)}"
+  end
+
+  def include
+    { asset: name, ghc: ghc, release: RELEASE_NAME }.
+      merge(os_attributes).
+      merge(version_attributes)
+  end
+
+  def os_attributes
+    case os
+    when "linux"
+      { runner: "ubuntu-latest", ext: "tar.gz", zip: "tar -czf" }
+    when "darwin"
+      { runner: "macOS-latest", ext: "tar.gz", zip: "tar -czf" }
+    when "win32"
+      { runner: "windows-latest", ext: "zip", zip: "zip" }
+    else
+      raise "Unexpected OS: #{os}, must be linux|darwin|win32"
+    end
+  end
+
+  def version_attributes
+    case ghc
+    when /9\.2\..*/
+      {
+        version: "2.4.0",
+        resolver: "lts-20.3",
+        "extra-deps": ""
+      }
+    when /9\.0\..*/
+      {
+        version: "2.3.1",
+        resolver: "lts-19.33",
+        "extra-deps": ""
+      }
+    when /8\.10\..*/
+      {
+        version: "2.2.0",
+        resolver: "lts-18.28",
+        "extra-deps": [
+            "dhall-1.40.2",
+            "generic-lens-2.2.1.0",
+            "generic-lens-core-2.2.1.0"
+        ].join(",")
+      }
+    when /8\.8\..*/
+      {
+        version: "2.2.0",
+        resolver: "lts-16.31",
+        "extra-deps": [
+            "dhall-1.40.2",
+            "generic-lens-2.2.1.0",
+            "generic-lens-core-2.2.1.0",
+            "base16-bytestring-1.0.2.0",
+            "prettyprinter-1.7.1",
+            "repline-0.4.2.0",
+            "haskeline-0.8.2"
+        ].join(",")
+      }
+    end
+  end
+
+  def needed?
+    !EXISTING_ASSETS.include?(name)
+  end
+end
+
+def generate_matrix
+  assets = %W[ linux darwin ].
+    flat_map { |os| GHCs.map { |ghc| Asset.new(ghc, os) } }.
+    filter(&:needed?)
+
+  {
+    asset: assets.map(&:name),
+    include: assets.map(&:include)
+  }
+end
+
+puts JSON.dump(generate_matrix)

--- a/.github/bin/build-binaries-matrix
+++ b/.github/bin/build-binaries-matrix
@@ -46,7 +46,7 @@ Asset = Struct.new(:ghc, :os) do
     when "darwin"
       { runner: "macOS-latest", ext: "tar.gz", zip: "tar -czf" }
     when "win32"
-      { runner: "windows-latest", ext: "zip", zip: 'C:\Program Files\7-Zip\7z.exe' }
+      { runner: "windows-latest", ext: "7z", zip: 'C:\Program Files\7-Zip\7z.exe' }
     else
       raise "Unexpected OS: #{os}, must be linux|darwin|win32"
     end

--- a/.github/bin/build-binaries-matrix
+++ b/.github/bin/build-binaries-matrix
@@ -42,11 +42,11 @@ Asset = Struct.new(:ghc, :os) do
   def os_attributes
     case os
     when "linux"
-      { runner: "ubuntu-latest", ext: "tar.gz", zip: "tar -czf" }
+      { runner: "ubuntu-latest", exe: "./weeder", ext: "tar.gz", zip: "tar -czf" }
     when "darwin"
-      { runner: "macOS-latest", ext: "tar.gz", zip: "tar -czf" }
+      { runner: "macOS-latest", exe: "./weeder", ext: "tar.gz", zip: "tar -czf" }
     when "win32"
-      { runner: "windows-latest", ext: "zip", zip: '"C:\Program Files\7-Zip\7z.exe" a -tzip' }
+      { runner: "windows-latest", exe: "./weeder.exe", ext: "zip", zip: '"C:\Program Files\7-Zip\7z.exe" a -tzip' }
     else
       raise "Unexpected OS: #{os}, must be linux|darwin|win32"
     end

--- a/.github/bin/build-binaries-matrix
+++ b/.github/bin/build-binaries-matrix
@@ -103,10 +103,20 @@ def generate_matrix
     flat_map { |os| GHCs.map { |ghc| Asset.new(ghc, os) } }.
     filter(&:needed?)
 
-  {
-    asset: assets.map(&:name),
-    include: assets.map(&:include)
-  }
+  if assets.empty?
+    {
+      asset: ["none"],
+      include: [{
+        asset: "none",
+        runner: "ubuntu-latest"
+      }]
+    }
+  else
+    {
+      asset: assets.map(&:name),
+      include: assets.map(&:include)
+    }
+  end
 end
 
 puts JSON.dump(generate_matrix)

--- a/.github/bin/build-binaries-matrix
+++ b/.github/bin/build-binaries-matrix
@@ -99,7 +99,7 @@ Asset = Struct.new(:ghc, :os) do
 end
 
 def generate_matrix
-  assets = %W[ linux darwin ].
+  assets = %W[ linux darwin win32 ].
     flat_map { |os| GHCs.map { |ghc| Asset.new(ghc, os) } }.
     filter(&:needed?)
 

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -1,0 +1,53 @@
+name: Binaries
+
+on:
+  pull_request:
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - id: generate
+        run: |
+          cat >>"$GITHUB_OUTPUT" <<EOM
+          matrix<<EOJSON
+          $(./.github/bin/build-binaries-matrix)
+          EOJSON
+          EOM
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    outputs:
+      matrix: ${{ steps.generate.outputs.matrix }}
+
+  binaries:
+    needs: generate
+
+    strategy:
+      matrix: ${{ fromJSON(needs.generate.outputs.matrix) }}
+      fail-fast: false
+
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.stack
+            ./.stack-work
+          key: ${{ runner.os }}-stack-${{ matrix.ghc }}
+          restore-keys: |
+            ${{ runner.os }}-stack-
+
+      - run: |
+          cat >stack.yaml <<'EOM'
+          resolver: ${{ matrix.resolver }}
+          packages: []
+          extra-deps: [${{ matrix.extra-deps }}]
+          EOM
+
+          stack install weeder-${{ matrix.version }} --local-bin-path .
+
+          ${{ matrix.zip }} '${{ matrix.asset }}' ./weeder
+          gh --repo '${{ github.repository }}' release upload '${{ matrix.release }}' '${{ matrix.asset }}'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -50,7 +50,7 @@ jobs:
 
           stack install weeder-${{ matrix.version }} --local-bin-path .
 
-          ${{ matrix.zip }} '${{ matrix.asset }}' ./weeder
+          ${{ matrix.zip }} '${{ matrix.asset }}' ${{ matrix.exe }}
           gh --repo '${{ github.repository }}' release upload '${{ matrix.release }}' '${{ matrix.asset }}'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -29,7 +29,8 @@ jobs:
 
     runs-on: ${{ matrix.runner }}
     steps:
-      - uses: actions/cache@v3
+      - if: ${{ matrix.asset != 'none' }}
+        uses: actions/cache@v3
         with:
           path: |
             ~/.stack
@@ -38,7 +39,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-stack-
 
-      - run: |
+      - if: ${{ matrix.asset != 'none' }}
+        run: |
           cat >stack.yaml <<'EOM'
           resolver: ${{ matrix.resolver }}
           packages: []

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -40,6 +40,7 @@ jobs:
             ${{ runner.os }}-stack-
 
       - if: ${{ matrix.asset != 'none' }}
+        shell: bash
         run: |
           cat >stack.yaml <<'EOM'
           resolver: ${{ matrix.resolver }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,21 +11,19 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: freckle/stack-cache-action@main
+      - uses: freckle/stack-cache-action@v2
         with:
           working-directory: example
 
-      - uses: freckle/stack-action@main
+      - uses: freckle/stack-action@v3
         with:
           working-directory: example
-          hlint: false
-          weeder: false
 
       - id: weeder
         uses: ./
         with:
+          ghc-version: 9.2.5
           working-directory: example
-          weeder-version: 2.2.0
           fail: false
 
       - run: |

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ steps:
 
 ## Inputs
 
-- **ghc-version**: You must specify the `ghc-version` your project
-  is compiled with (to ensure `.hie` compatibility).
+- **ghc-version**: You must specify the `ghc-version` your project is compiled
+  with (to ensure `.hie` compatibility).
 
   This Action maintains and installs pre-compiled `weeder` binaries for Mac and
   Linux across all GHC versions that `weeder` compiles on (8.8.1 to 9.2.5 at

--- a/README.md
+++ b/README.md
@@ -26,10 +26,8 @@ steps:
 
 ## Inputs
 
-- **ghc-version**: The version of `weeder` to install and run
-
-  You must specify the `ghc-version` your project is compiled with (to ensure
-  `.hie` compatibility).
+- **ghc-version**: You must specify the `ghc-version` your project
+  is compiled with (to ensure `.hie` compatibility).
 
   This Action maintains and installs pre-compiled `weeder` binaries for Mac and
   Linux across all GHC versions that `weeder` compiles on (8.8.1 to 9.2.5 at

--- a/README.md
+++ b/README.md
@@ -14,12 +14,6 @@ See the [Weeder README][weeder] for project requirements.
 You will need to run this step in the same Job as you compile your project, or
 make the `.hie` files available some other way.
 
-This Action only supports [Stack]-based projects at this time: it uses
-`stack install` to install `weeder` and `stack exec` to run it. PRs are very
-welcome to support alternatives such as Cabal or Nix.
-
-[stack]: https://docs.haskellstack.org/en/stable/README/
-
 ## Usage
 
 ```yaml
@@ -32,7 +26,30 @@ steps:
 
 ## Inputs
 
-See [`action.yml`](./action.yml) for a complete and up to date list.
+- **ghc-version**: The version of `weeder` to install and run
+
+  You must specify the `ghc-version` your project is compiled with (to ensure
+  `.hie` compatibility).
+
+  This Action maintains and installs pre-compiled `weeder` binaries for Mac and
+  Linux across all GHC versions that `weeder` compiles on (8.8.1 to 9.2.5 at
+  time of this writing). Please file an Issue if you're using a GHC that's not
+  supported, but for which a released version of `weeder` does exist.
+
+- **weeder-arguments**: Arguments to pass when invoking `weeder`
+
+  Default is `--require-hs-files`, which ensures that cached builds that have
+  since removed files (but still have their `.hie` files present) don't generate
+  false positives.
+
+- **working-directory**: Change to this directory before running.
+
+  This can be necessary if in a mono-repository.
+
+- **fail**: Fail if we find unused functions?
+
+  Default is true. This is useful if you want to not fail the step, but do
+  something else with the weeder output yourself.
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -1,23 +1,18 @@
 name: Weeder
 description: Annotate unused functions in a Haskell project
 inputs:
-  working-directory:
-    description: Change to this directory before operating
+  ghc-version:
+    description: Full version of GHC your project uses (required)
     required: true
-    default: .
-  stack-yaml:
-    description: Path to stack.yaml, relative to working-directory
-    required: true
-    default: stack.yaml
-  weeder-version:
-    description: Version of weeder to install (default latest)
-    required: true
-    default: ""
   weeder-arguments:
     description: |
       Arguments to pass when invoking weeder (default --require-hs-files)
     required: true
     default: --require-hs-files
+  working-directory:
+    description: Change to this directory before operating
+    required: true
+    default: .
   fail:
     description: Fail the build if unused functions found? (default true)
     required: true
@@ -30,17 +25,11 @@ runs:
   using: composite
   steps:
     - name: Install weeder
-      shell: bash
-      run: |
-        if [[ -n "${{ inputs.weeder-version }}" ]]; then
-          package=weeder-${{ inputs.weeder-version }}
-        else
-          package=weeder
-        fi
-
-        cd '${{ inputs.working-directory }}'
-        stack --stack-yaml '${{ inputs.stack-yaml }}' install \
-          --copy-compiler-tool "$package"
+      uses: pbrisbin/setup-tool-action@v1.0.0
+      with:
+        name: weeder
+        version: ${{ inputs.ghc-version }}
+        url: "https://github.com/freckle/weeder-action/releases/download/Binaries/{name}-{version}-{os}-{arch}.{ext}"
 
     - id: weeder
       name: Run weeder
@@ -54,8 +43,7 @@ runs:
 
         cd '${{ inputs.working-directory }}'
         prefix=$(echo '${{ inputs.working-directory }}' | sed 's|/$||')/
-        stack --stack-yaml '${{ inputs.stack-yaml }}' exec -- \
-          weeder ${{ inputs.weeder-arguments }} |
+        weeder ${{ inputs.weeder-arguments }} |
           sed "s|^|$prefix|; "'s/$/ is not used by any defined root/' |
           tee "$tmp" || true
 

--- a/example/stack.yaml
+++ b/example/stack.yaml
@@ -1,7 +1,3 @@
-resolver: lts-18.16
-extra-deps:
-  - dhall-1.40.1@sha256:ecc984210717ae2785a02c31c8b10c23a854761dba60c09adf533459bf5fe9b6,35396
-  - generic-lens-2.2.0.0@sha256:4008a39f464e377130346e46062e2ac1211f9d2e256bbb1857216e889c7196be,3867
-  - generic-lens-core-2.2.0.0@sha256:b6b69e992f15fa80001de737f41f2123059011a1163d6c8941ce2e3ab44f8c03,2913
+resolver: lts-20.3
 ghc-options:
   "$locals": -fwrite-ide-info

--- a/example/stack.yaml.lock
+++ b/example/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    size: 586286
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/16.yaml
-    sha256: cdead65fca0323144b346c94286186f4969bf85594d649c49c7557295675d8a5
-  original: lts-18.16
+    sha256: 03cec7d96ed78877b03b5c2bc5e31015b47f69af2fe6a62d994a42b7a43c5805
+    size: 648659
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/3.yaml
+  original: lts-20.3


### PR DESCRIPTION
Making users wait for a `stack install weeder` is an unnecessary tax on
every CI run that lacks a complete cache. Instead, this PR adds an
"Binaries" action that builds binaries across a runner/GHC matrix and
stores them on a Release for use by the action. The Binaries action is
idempotent and has been run and added all the binaries already, which
our own CI uses successfully.

I made binaries for Linux and Mac and GHCs 8.8.1 to 9.2.5. Windows may
be possible, but the `prep` step needs to be rewritten for that
platform. These are all the GHC versions for which a released version of
`weeder` exists, so it should cover all users.

Arguably, these binaries should be released by the weeder project
itself. I may open an Issue soon to see if they'd be open to upstreaming
something like tooling I have here, which is pretty non-standard due to
the need to version by GHC and not by weeder.