### PR TITLE
Refactor Binaries build process, add 9.2.6 and 9.2.7 binaries

### DIFF
--- a/.github/bin/build-binaries-matrix
+++ b/.github/bin/build-binaries-matrix
@@ -3,10 +3,15 @@ require "json"
 
 RELEASE_NAME = "Binaries"
 
-EXISTING_ASSETS = JSON.parse(`
-  gh --repo freckle/weeder-action release view #{RELEASE_NAME} --json assets |
-    jq '.assets | map(.name)'
-`)
+EXISTING_ASSETS =
+  if ENV["WEEDER_BINARIES_OVERWRITE"] == "1"
+    []
+  else
+    JSON.parse(`
+      gh --repo freckle/weeder-action release view #{RELEASE_NAME} --json assets |
+        jq '.assets | map(.name)'
+    `)
+  end
 
 GHCs = %W[
   9.2.7

--- a/.github/bin/build-binaries-matrix
+++ b/.github/bin/build-binaries-matrix
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 require "json"
+require "yaml"
 
 RELEASE_NAME = "Binaries"
 
@@ -13,103 +14,15 @@ EXISTING_ASSETS =
     `)
   end
 
-GHCs = %W[
-  9.2.7
-  9.2.6
-  9.2.5
-  9.2.4
-  9.2.3
-  9.2.2
-  9.0.2
-  9.0.1
-  8.10.7
-  8.10.6
-  8.10.5
-  8.10.4
-  8.10.3
-  8.10.2
-  8.10.1
-  8.8.4
-  8.8.3
-  8.8.2
-  8.8.1
-]
-
-Asset = Struct.new(:ghc, :os) do
+Asset = Struct.new(:os, :os_attributes, :ghc, :ghc_attributes) do
   def name
-    "weeder-#{ghc}-#{os}-x64.#{os_attributes.fetch(:ext)}"
+    "weeder-#{ghc}-#{os}-x64.#{os_attributes.fetch("ext")}"
   end
 
   def include
     { asset: name, ghc: ghc, release: RELEASE_NAME }.
       merge(os_attributes).
-      merge(version_attributes)
-  end
-
-  def os_attributes
-    case os
-    when "linux"
-      { runner: "ubuntu-latest", exe: "./weeder", ext: "tar.gz", zip: "tar -czf" }
-    when "darwin"
-      { runner: "macOS-latest", exe: "./weeder", ext: "tar.gz", zip: "tar -czf" }
-    when "win32"
-      { runner: "windows-latest", exe: "./weeder.exe", ext: "zip", zip: '"C:\Program Files\7-Zip\7z.exe" a -tzip' }
-    else
-      raise "Unexpected OS: #{os}, must be linux|darwin|win32"
-    end
-  end
-
-  def version_attributes
-    case ghc
-    when /9\.2\.7/
-      {
-        version: "2.4.0",
-        resolver: "lts-20.13",
-        "extra-deps": ""
-      }
-    when /9\.2\.6/
-      {
-        version: "2.4.0",
-        resolver: "lts-20.12",
-        "extra-deps": ""
-      }
-    when /9\.2\..*/
-      {
-        version: "2.4.0",
-        resolver: "lts-20.3",
-        "extra-deps": ""
-      }
-    when /9\.0\..*/
-      {
-        version: "2.3.1",
-        resolver: "lts-19.33",
-        "extra-deps": ""
-      }
-    when /8\.10\..*/
-      {
-        version: "2.2.0",
-        resolver: "lts-18.28",
-        "extra-deps": [
-            "dhall-1.40.2",
-            "generic-lens-2.2.1.0",
-            "generic-lens-core-2.2.1.0"
-        ].join(",")
-      }
-    when /8\.8\..*/
-      {
-        version: "2.2.0",
-        resolver: "lts-16.31",
-        "extra-deps": [
-            "dhall-1.40.2",
-            "generic-lens-2.2.1.0",
-            "generic-lens-core-2.2.1.0",
-            "base16-bytestring-1.0.2.0",
-            "prettyprinter-1.7.1",
-            "repline-0.4.2.0",
-            "haskeline-0.8.2"
-        ].join(",")
-      }
-    end
+      merge(ghc_attributes)
   end
 
   def needed?
@@ -118,9 +31,15 @@ Asset = Struct.new(:ghc, :os) do
 end
 
 def generate_matrix
-  assets = %W[ linux darwin win32 ].
-    flat_map { |os| GHCs.map { |ghc| Asset.new(ghc, os) } }.
-    filter(&:needed?)
+  binaries = YAML.load_file("binaries.yaml")
+  oses = binaries.fetch("oses")
+  ghcs = binaries.fetch("ghcs")
+
+  assets = oses.flat_map do |os, os_attributes|
+    ghcs.map do |ghc, ghc_attributes|
+      Asset.new(os, os_attributes, ghc.sub(/^ghc-/, ""), ghc_attributes)
+    end
+  end.filter(&:needed?)
 
   if assets.empty?
     {

--- a/.github/bin/build-binaries-matrix
+++ b/.github/bin/build-binaries-matrix
@@ -56,6 +56,18 @@ Asset = Struct.new(:ghc, :os) do
 
   def version_attributes
     case ghc
+    when /9\.2\.7/
+      {
+        version: "2.4.0",
+        resolver: "lts-20.13",
+        "extra-deps": ""
+      }
+    when /9\.2\.6/
+      {
+        version: "2.4.0",
+        resolver: "lts-20.12",
+        "extra-deps": ""
+      }
     when /9\.2\..*/
       {
         version: "2.4.0",

--- a/.github/bin/build-binaries-matrix
+++ b/.github/bin/build-binaries-matrix
@@ -14,7 +14,7 @@ EXISTING_ASSETS =
     `)
   end
 
-Asset = Struct.new(:os, :os_attributes, :ghc, :ghc_attributes) do
+Asset = Struct.new(:os, :os_attributes, :ghc, :ghc_attributes, :excludes) do
   def name
     "weeder-#{ghc}-#{os}-x64.#{os_attributes.fetch("ext")}"
   end
@@ -26,7 +26,11 @@ Asset = Struct.new(:os, :os_attributes, :ghc, :ghc_attributes) do
   end
 
   def needed?
-    !EXISTING_ASSETS.include?(name)
+    !excluded? && !EXISTING_ASSETS.include?(name)
+  end
+
+  def excluded?
+    excludes.include?("ghc-#{ghc}-#{os}")
   end
 end
 
@@ -34,10 +38,17 @@ def generate_matrix
   binaries = YAML.load_file("binaries.yaml")
   oses = binaries.fetch("oses")
   ghcs = binaries.fetch("ghcs")
+  excludes = binaries.fetch("excluded")
 
   assets = oses.flat_map do |os, os_attributes|
     ghcs.map do |ghc, ghc_attributes|
-      Asset.new(os, os_attributes, ghc.sub(/^ghc-/, ""), ghc_attributes)
+      Asset.new(
+        os,
+        os_attributes,
+        ghc.sub(/^ghc-/, ""),
+        ghc_attributes,
+        excludes
+      )
     end
   end.filter(&:needed?)
 

--- a/.github/bin/build-binaries-matrix
+++ b/.github/bin/build-binaries-matrix
@@ -9,6 +9,8 @@ EXISTING_ASSETS = JSON.parse(`
 `)
 
 GHCs = %W[
+  9.2.7
+  9.2.6
   9.2.5
   9.2.4
   9.2.3

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -48,6 +48,24 @@ jobs:
           extra-deps: [${{ matrix.extra-deps }}]
           EOM
 
+          stack setup
+
+          actual_ghc="$(stack query stack query compiler actual)"
+          wanted_ghc=ghc-${{ matrix.ghc }}
+
+          if [[ "$actual_ghc" != "$wanted_ghc" ]]; then
+            cat <<EOM
+          The configured GHC does not match the binary we're intending to build:
+
+            Actual: $actual_ghc
+            Wanted: $wanted_ghc
+
+          Update the resolver used for this build in build-binaries-matrix to
+          one that matches the desired GHC.
+          EOM
+            exit 1
+          fi
+
           stack install weeder-${{ matrix.version }} --local-bin-path .
 
           ${{ matrix.zip }} '${{ matrix.asset }}' ${{ matrix.exe }}

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -50,7 +50,7 @@ jobs:
 
           stack setup
 
-          actual_ghc="$(stack query stack query compiler actual)"
+          actual_ghc="$(stack query compiler actual)"
           wanted_ghc=ghc-${{ matrix.ghc }}
 
           if [[ "$actual_ghc" != "$wanted_ghc" ]]; then

--- a/binaries.yaml
+++ b/binaries.yaml
@@ -40,64 +40,44 @@ ghcs:
     version: 2.2.0
     resolver: lts-18.9
     extra-deps: >-
-      dhall-1.40.2,
-      generic-lens-2.2.1.0,
-      generic-lens-core-2.2.1.0
+      dhall-1.40.2, generic-lens-2.2.1.0, generic-lens-core-2.2.1.0
   ghc-8.10.6:
     version: 2.2.0
     resolver: lts-18.7
     extra-deps: >-
-      dhall-1.40.2,
-      generic-lens-2.2.1.0,
-      generic-lens-core-2.2.1.0
+      dhall-1.40.2, generic-lens-2.2.1.0, generic-lens-core-2.2.1.0
   # ghc-8.10.5:
   ghc-8.10.4:
     version: 2.2.0
     resolver: lts-17.3
     extra-deps: >-
-      dhall-1.40.2,
-      generic-lens-2.2.1.0,
-      generic-lens-core-2.2.1.0
+      dhall-1.40.2, generic-lens-2.2.1.0, generic-lens-core-2.2.1.0
   ghc-8.10.3:
     version: 2.2.0
     resolver: lts-17.0
     extra-deps: >-
-      dhall-1.40.2,
-      generic-lens-2.2.1.0,
-      generic-lens-core-2.2.1.0
+      dhall-1.40.2, generic-lens-2.2.1.0, generic-lens-core-2.2.1.0
   # ghc-8.10.2:
   # ghc-8.10.1:
   ghc-8.8.4:
     version: 2.2.0
     resolver: lts-16.12
     extra-deps: >-
-      dhall-1.40.2,
-      generic-lens-2.2.1.0,
-      generic-lens-core-2.2.1.0,
-      base16-bytestring-1.0.2.0,
-      prettyprinter-1.7.1,
-      repline-0.4.2.0,
+      dhall-1.40.2, generic-lens-2.2.1.0, generic-lens-core-2.2.1.0,
+      base16-bytestring-1.0.2.0, prettyprinter-1.7.1, repline-0.4.2.0,
       haskeline-0.8.2
   ghc-8.8.3:
     version: 2.2.0
     resolver: lts-15.4
     extra-deps: >-
-      dhall-1.40.2,
-      generic-lens-2.2.1.0,
-      generic-lens-core-2.2.1.0,
-      base16-bytestring-1.0.2.0,
-      prettyprinter-1.7.1,
-      repline-0.4.2.0,
+      dhall-1.40.2, generic-lens-2.2.1.0, generic-lens-core-2.2.1.0,
+      base16-bytestring-1.0.2.0, prettyprinter-1.7.1, repline-0.4.2.0,
       haskeline-0.8.2
   ghc-8.8.2:
     version: 2.2.0
     resolver: lts-15.0
     extra-deps: >-
-      dhall-1.40.2,
-      generic-lens-2.2.1.0,
-      generic-lens-core-2.2.1.0,
-      base16-bytestring-1.0.2.0,
-      prettyprinter-1.7.1,
-      repline-0.4.2.0,
+      dhall-1.40.2, generic-lens-2.2.1.0, generic-lens-core-2.2.1.0,
+      base16-bytestring-1.0.2.0, prettyprinter-1.7.1, repline-0.4.2.0,
       haskeline-0.8.2
   # ghc-8.8.1:

--- a/binaries.yaml
+++ b/binaries.yaml
@@ -90,20 +90,28 @@ ghcs:
       dhall-1.40.2, generic-lens-2.2.1.0, generic-lens-core-2.2.1.0,
       base16-bytestring-1.0.2.0, prettyprinter-1.7.1,
       prettyprinter-ansi-terminal-1.1.2, repline-0.4.2.0, haskeline-0.8.2
+  ghc-8.8.3:
+    version: 2.2.0
+    resolver: lts-15.4
+    extra-deps: >-
+      dhall-1.40.2, generic-lens-2.2.1.0, generic-lens-core-2.2.1.0,
+      base16-bytestring-1.0.2.0, prettyprinter-1.7.1,
+      prettyprinter-ansi-terminal-1.1.2, repline-0.4.2.0, haskeline-0.8.2
+  ghc-8.8.2:
+    version: 2.2.0
+    resolver: lts-15.0
+    extra-deps: >-
+      dhall-1.40.2, generic-lens-2.2.1.0, generic-lens-core-2.2.1.0,
+      base16-bytestring-1.0.2.0, prettyprinter-1.7.1,
+      prettyprinter-ansi-terminal-1.1.2, repline-0.4.2.0, haskeline-0.8.2
 
-  # panic! "Prelude.chr: bad argument: 2583691267" on Linux
-  # ghc-8.8.3:
-  #   version: 2.2.0
-  #   resolver: lts-15.4
-  #   extra-deps: >-
-  #     dhall-1.40.2, generic-lens-2.2.1.0, generic-lens-core-2.2.1.0,
-  #     base16-bytestring-1.0.2.0, prettyprinter-1.7.1,
-  #     prettyprinter-ansi-terminal-1.1.2, repline-0.4.2.0, haskeline-0.8.2
-  # ghc-8.8.2:
-  #   version: 2.2.0
-  #   resolver: lts-15.0
-  #   extra-deps: >-
-  #     dhall-1.40.2, generic-lens-2.2.1.0, generic-lens-core-2.2.1.0,
-  #     base16-bytestring-1.0.2.0, prettyprinter-1.7.1,
-  #     prettyprinter-ansi-terminal-1.1.2, repline-0.4.2.0, haskeline-0.8.2
+  # No LTS
   # ghc-8.8.1:
+
+excluded:
+  - "ghc-8.10.6-win32" # tons of "this GHC boot package has been pruned" errors
+  - "ghc-8.8.3-linux" # panic! "Prelude.chr: bad argument: 2583691267"
+  - "ghc-8.8.3-darwin" # panic! "Prelude.chr: bad argument: 2583691267"
+  - "ghc-8.8.3-win32" # Access violation in generated code when writing 0x0
+  - "ghc-8.8.2-linux" # panic! "Prelude.chr: bad argument: 2583691267"
+  - "ghc-8.8.2-darwin" # panic! "Prelude.chr: bad argument: 2583691267"

--- a/binaries.yaml
+++ b/binaries.yaml
@@ -16,6 +16,14 @@ oses:
     zip: '"C:\Program Files\7-Zip\7z.exe" a -tzip'
 
 ghcs:
+  # No LTS
+  # ghc-9.6.1:
+  # ghc-9.4.4:
+  # ghc-9.4.3:
+  # ghc-9.4.2:
+  # ghc-9.4.1:
+  # ghc-9.4.0:
+
   ghc-9.2.7:
     version: 2.4.0
     resolver: lts-20.13
@@ -28,14 +36,20 @@ ghcs:
     version: 2.4.0
     resolver: lts-20.0
     extra-deps: ""
+
+  # No LTS
   # ghc-9.2.4:
   # ghc-9.2.3:
   # ghc-9.2.2:
+
   ghc-9.0.2:
     resolver: lts-19.0
     version: 2.3.1
     extra-deps: ""
+
+  # No LTS
   # ghc-9.0.1:
+
   ghc-8.10.7:
     version: 2.2.0
     resolver: lts-18.9
@@ -48,7 +62,10 @@ ghcs:
     extra-deps: >-
       base16-bytestring-1.0.0.0, dhall-1.40.2, generic-lens-2.2.1.0,
       generic-lens-core-2.2.1.0
+
+  # No LTS
   # ghc-8.10.5:
+
   ghc-8.10.4:
     version: 2.2.0
     resolver: lts-17.3
@@ -61,8 +78,11 @@ ghcs:
     extra-deps: >-
       base16-bytestring-1.0.0.0, dhall-1.40.2, generic-lens-2.2.1.0,
       generic-lens-core-2.2.1.0
+
+  # No LTS
   # ghc-8.10.2:
   # ghc-8.10.1:
+
   ghc-8.8.4:
     version: 2.2.0
     resolver: lts-16.12

--- a/binaries.yaml
+++ b/binaries.yaml
@@ -1,0 +1,103 @@
+oses:
+  linux:
+    runner: ubuntu-latest
+    exe: ./weeder
+    ext: tar.gz
+    zip: tar -czf
+  darwin:
+    runner: macOS-latest
+    exe: ./weeder
+    ext: tar.gz
+    zip: tar -czf
+  win32:
+    runner: windows-latest
+    exe: ./weeder.exe
+    ext: zip
+    zip: '"C:\Program Files\7-Zip\7z.exe" a -tzip'
+
+ghcs:
+  ghc-9.2.7:
+    version: 2.4.0
+    resolver: lts-20.13
+    extra-deps: ""
+  ghc-9.2.6:
+    version: 2.4.0
+    resolver: lts-20.12
+    extra-deps: ""
+  ghc-9.2.5:
+    version: 2.4.0
+    resolver: lts-20.0
+    extra-deps: ""
+  # ghc-9.2.4:
+  # ghc-9.2.3:
+  # ghc-9.2.2:
+  ghc-9.0.2:
+    resolver: lts-19.0
+    version: 2.3.1
+    extra-deps: ""
+  # ghc-9.0.1:
+  ghc-8.10.7:
+    version: 2.2.0
+    resolver: lts-18.9
+    extra-deps: >-
+      dhall-1.40.2,
+      generic-lens-2.2.1.0,
+      generic-lens-core-2.2.1.0
+  ghc-8.10.6:
+    version: 2.2.0
+    resolver: lts-18.7
+    extra-deps: >-
+      dhall-1.40.2,
+      generic-lens-2.2.1.0,
+      generic-lens-core-2.2.1.0
+  # ghc-8.10.5:
+  ghc-8.10.4:
+    version: 2.2.0
+    resolver: lts-17.3
+    extra-deps: >-
+      dhall-1.40.2,
+      generic-lens-2.2.1.0,
+      generic-lens-core-2.2.1.0
+  ghc-8.10.3:
+    version: 2.2.0
+    resolver: lts-17.0
+    extra-deps: >-
+      dhall-1.40.2,
+      generic-lens-2.2.1.0,
+      generic-lens-core-2.2.1.0
+  # ghc-8.10.2:
+  # ghc-8.10.1:
+  ghc-8.8.4:
+    version: 2.2.0
+    resolver: lts-16.12
+    extra-deps: >-
+      dhall-1.40.2,
+      generic-lens-2.2.1.0,
+      generic-lens-core-2.2.1.0,
+      base16-bytestring-1.0.2.0,
+      prettyprinter-1.7.1,
+      repline-0.4.2.0,
+      haskeline-0.8.2
+  ghc-8.8.3:
+    version: 2.2.0
+    resolver: lts-15.4
+    extra-deps: >-
+      dhall-1.40.2,
+      generic-lens-2.2.1.0,
+      generic-lens-core-2.2.1.0,
+      base16-bytestring-1.0.2.0,
+      prettyprinter-1.7.1,
+      repline-0.4.2.0,
+      haskeline-0.8.2
+  ghc-8.8.2:
+    version: 2.2.0
+    resolver: lts-15.0
+    extra-deps: >-
+      dhall-1.40.2,
+      generic-lens-2.2.1.0,
+      generic-lens-core-2.2.1.0,
+      base16-bytestring-1.0.2.0,
+      prettyprinter-1.7.1,
+      repline-0.4.2.0,
+      haskeline-0.8.2
+  # ghc-8.8.1:

--- a/binaries.yaml
+++ b/binaries.yaml
@@ -40,23 +40,27 @@ ghcs:
     version: 2.2.0
     resolver: lts-18.9
     extra-deps: >-
-      dhall-1.40.2, generic-lens-2.2.1.0, generic-lens-core-2.2.1.0
+      base16-bytestring-1.0.0.0, dhall-1.40.2, generic-lens-2.2.1.0,
+      generic-lens-core-2.2.1.0
   ghc-8.10.6:
     version: 2.2.0
     resolver: lts-18.7
     extra-deps: >-
-      dhall-1.40.2, generic-lens-2.2.1.0, generic-lens-core-2.2.1.0
+      base16-bytestring-1.0.0.0, dhall-1.40.2, generic-lens-2.2.1.0,
+      generic-lens-core-2.2.1.0
   # ghc-8.10.5:
   ghc-8.10.4:
     version: 2.2.0
     resolver: lts-17.3
     extra-deps: >-
-      dhall-1.40.2, generic-lens-2.2.1.0, generic-lens-core-2.2.1.0
+      base16-bytestring-1.0.0.0, dhall-1.40.2, generic-lens-2.2.1.0,
+      generic-lens-core-2.2.1.0
   ghc-8.10.3:
     version: 2.2.0
     resolver: lts-17.0
     extra-deps: >-
-      dhall-1.40.2, generic-lens-2.2.1.0, generic-lens-core-2.2.1.0
+      base16-bytestring-1.0.0.0, dhall-1.40.2, generic-lens-2.2.1.0,
+      generic-lens-core-2.2.1.0
   # ghc-8.10.2:
   # ghc-8.10.1:
   ghc-8.8.4:

--- a/binaries.yaml
+++ b/binaries.yaml
@@ -16,7 +16,7 @@ oses:
     zip: '"C:\Program Files\7-Zip\7z.exe" a -tzip'
 
 ghcs:
-  # No LTS
+  # Awaiting LTS availability
   # ghc-9.6.1:
   # ghc-9.4.4:
   # ghc-9.4.3:
@@ -36,20 +36,10 @@ ghcs:
     version: 2.4.0
     resolver: lts-20.0
     extra-deps: ""
-
-  # No LTS
-  # ghc-9.2.4:
-  # ghc-9.2.3:
-  # ghc-9.2.2:
-
   ghc-9.0.2:
     resolver: lts-19.0
     version: 2.3.1
     extra-deps: ""
-
-  # No LTS
-  # ghc-9.0.1:
-
   ghc-8.10.7:
     version: 2.2.0
     resolver: lts-18.9
@@ -62,10 +52,6 @@ ghcs:
     extra-deps: >-
       base16-bytestring-1.0.0.0, dhall-1.40.2, generic-lens-2.2.1.0,
       generic-lens-core-2.2.1.0
-
-  # No LTS
-  # ghc-8.10.5:
-
   ghc-8.10.4:
     version: 2.2.0
     resolver: lts-17.3
@@ -78,11 +64,6 @@ ghcs:
     extra-deps: >-
       base16-bytestring-1.0.0.0, dhall-1.40.2, generic-lens-2.2.1.0,
       generic-lens-core-2.2.1.0
-
-  # No LTS
-  # ghc-8.10.2:
-  # ghc-8.10.1:
-
   ghc-8.8.4:
     version: 2.2.0
     resolver: lts-16.12
@@ -104,9 +85,6 @@ ghcs:
       dhall-1.40.2, generic-lens-2.2.1.0, generic-lens-core-2.2.1.0,
       base16-bytestring-1.0.2.0, prettyprinter-1.7.1,
       prettyprinter-ansi-terminal-1.1.2, repline-0.4.2.0, haskeline-0.8.2
-
-  # No LTS
-  # ghc-8.8.1:
 
 excluded:
   - "ghc-8.10.6-win32" # tons of "this GHC boot package has been pruned" errors

--- a/binaries.yaml
+++ b/binaries.yaml
@@ -70,18 +70,20 @@ ghcs:
       dhall-1.40.2, generic-lens-2.2.1.0, generic-lens-core-2.2.1.0,
       base16-bytestring-1.0.2.0, prettyprinter-1.7.1,
       prettyprinter-ansi-terminal-1.1.2, repline-0.4.2.0, haskeline-0.8.2
-  ghc-8.8.3:
-    version: 2.2.0
-    resolver: lts-15.4
-    extra-deps: >-
-      dhall-1.40.2, generic-lens-2.2.1.0, generic-lens-core-2.2.1.0,
-      base16-bytestring-1.0.2.0, prettyprinter-1.7.1,
-      prettyprinter-ansi-terminal-1.1.2, repline-0.4.2.0, haskeline-0.8.2
-  ghc-8.8.2:
-    version: 2.2.0
-    resolver: lts-15.0
-    extra-deps: >-
-      dhall-1.40.2, generic-lens-2.2.1.0, generic-lens-core-2.2.1.0,
-      base16-bytestring-1.0.2.0, prettyprinter-1.7.1,
-      prettyprinter-ansi-terminal-1.1.2, repline-0.4.2.0, haskeline-0.8.2
+
+  # panic! "Prelude.chr: bad argument: 2583691267" on Linux
+  # ghc-8.8.3:
+  #   version: 2.2.0
+  #   resolver: lts-15.4
+  #   extra-deps: >-
+  #     dhall-1.40.2, generic-lens-2.2.1.0, generic-lens-core-2.2.1.0,
+  #     base16-bytestring-1.0.2.0, prettyprinter-1.7.1,
+  #     prettyprinter-ansi-terminal-1.1.2, repline-0.4.2.0, haskeline-0.8.2
+  # ghc-8.8.2:
+  #   version: 2.2.0
+  #   resolver: lts-15.0
+  #   extra-deps: >-
+  #     dhall-1.40.2, generic-lens-2.2.1.0, generic-lens-core-2.2.1.0,
+  #     base16-bytestring-1.0.2.0, prettyprinter-1.7.1,
+  #     prettyprinter-ansi-terminal-1.1.2, repline-0.4.2.0, haskeline-0.8.2
   # ghc-8.8.1:

--- a/binaries.yaml
+++ b/binaries.yaml
@@ -64,20 +64,20 @@ ghcs:
     resolver: lts-16.12
     extra-deps: >-
       dhall-1.40.2, generic-lens-2.2.1.0, generic-lens-core-2.2.1.0,
-      base16-bytestring-1.0.2.0, prettyprinter-1.7.1, repline-0.4.2.0,
-      haskeline-0.8.2
+      base16-bytestring-1.0.2.0, prettyprinter-1.7.1,
+      prettyprinter-ansi-terminal-1.1.2, repline-0.4.2.0, haskeline-0.8.2
   ghc-8.8.3:
     version: 2.2.0
     resolver: lts-15.4
     extra-deps: >-
       dhall-1.40.2, generic-lens-2.2.1.0, generic-lens-core-2.2.1.0,
-      base16-bytestring-1.0.2.0, prettyprinter-1.7.1, repline-0.4.2.0,
-      haskeline-0.8.2
+      base16-bytestring-1.0.2.0, prettyprinter-1.7.1,
+      prettyprinter-ansi-terminal-1.1.2, repline-0.4.2.0, haskeline-0.8.2
   ghc-8.8.2:
     version: 2.2.0
     resolver: lts-15.0
     extra-deps: >-
       dhall-1.40.2, generic-lens-2.2.1.0, generic-lens-core-2.2.1.0,
-      base16-bytestring-1.0.2.0, prettyprinter-1.7.1, repline-0.4.2.0,
-      haskeline-0.8.2
+      base16-bytestring-1.0.2.0, prettyprinter-1.7.1,
+      prettyprinter-ansi-terminal-1.1.2, repline-0.4.2.0, haskeline-0.8.2
   # ghc-8.8.1:


### PR DESCRIPTION
This PR originally started as simply adding binaries for GHC-9.2.6/7, but that exposed a bug
in that a lot of our binaries were using the wrong LTS and we built binaries that would not
work on projects using the claimed GHC due to HIE mismatches.

So, I then:

- Implemented a check in the workflow that were in fact building with the GHC we meant to
- Exposed all broken Binaries through this check
- Replaced all broken Binaries

Doing this motivated the refactors to make it easier to specify specific details by GHC, rather than
the "by major version" logic that was embedded in the Ruby (the source of the bug).

Once we were building with correct GHCs, we uncovered some builds that just don't work due to
various bugs in GHC on those versions/platforms. So an "exclude" system was added.

Finally, we got all the Binaries build and the assets added back on the Release. We lost some GHC
versions in this process, but those binaries were not useful to begin with.