### PR TITLE
chore: Add GHC 9.6.5

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -40,6 +40,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-stack-
 
+      - if: ${{ runner.os == 'macOS' }}
+        run: curl -sSL https://get.haskellstack.org/ | sh
+
       - if: ${{ matrix.asset != 'none' }}
         shell: bash
         run: |

--- a/binaries.yaml
+++ b/binaries.yaml
@@ -16,6 +16,11 @@ oses:
     zip: '"C:\Program Files\7-Zip\7z.exe" a -tzip'
 
 ghcs:
+  ghc-9.6.5:
+    version: 2.7.0
+    resolver: lts-22.21
+    extra-deps: >-
+      ansi-wl-pprint-0.6.9, optparse-applicative-0.17.1.0
   ghc-9.6.4:
     version: 2.7.0
     resolver: lts-22.9


### PR DESCRIPTION
Due to some segfault issues when running `make build` in text-assets, I had to bump up the text-assets GHC version to 9.6.5 (LTS 22.21). This PR adds support for GHC 9.6.5 to the weeder GitHub action

The issues in question were often:

```
make: *** [build] Bus error: 10
```

and less often:

```
text-assets: internal error: ARR_WORDS object (0x16e4f2e40) entered!
    (GHC version 9.6.3 for aarch64_apple_darwin)
    Please report this as a GHC bug:  https://www.haskell.org/ghc/reportabug
make: *** [build] Abort trap: 6
```