### PR TITLE
Update conditions around unused functions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -70,22 +70,32 @@ runs:
           ret=${PIPESTATUS[0]} # can't trust $? here, apparently
         fi
 
-        echo "Weeder exit code: $ret"
+        unused_functions_found=0
+
+        if ((WEEDER_VERCMP >= 0)); then
+          if ((ret == 228)); then
+            unused_functions_found=1
+          fi
+        else
+          if [[ -s "$tmp" ]]; then
+            unused_functions_found=1
+          fi
+        fi
 
         if ((!ret)); then
           echo "No unused functions found"
           exit 0
         fi
 
-        # If we're configured to fail, we can always fail regardless of version
-        if ${{ inputs.fail }}; then
-          echo "Configured to fail and unused functions found"
-          exit $ret
+        if ((unused_functions_found)); then
+          if ${{ inputs.fail }}; then
+            echo "Configured to fail and unused functions found"
+            exit 1
+          fi
+
+          echo "Unused functions found, but not configured to fail"
+          exit 0
         fi
 
-        # Otherwise, if we know we're v2.7+ and the exit code was not
-        # weeds-found (228), we should still fail.
-        if ((WEEDER_VERCMP >= 0)) && ((ret != 228)); then
-          echo "Weeder encountered some other error" >&2
-          exit $ret
-        fi
+        echo "Weeder encountered some other error" >&2
+        exit $ret


### PR DESCRIPTION
This is behavior neutral, but it corrects that fact that we output
"unused functions found" for any error, regardless of the version of
weeder (i.e. even when we can trust its exit code to know). Now this
should output "unused functions found" or "some other error" correctly.

We did the code the way it was originally to minimize diff when
introducing the logic based on weeder version, which required larger
changes elsewhere.
