### PR TITLE
fix: use node24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,5 +23,5 @@ outputs:
       Path to a file containing found weeds in JSON format; a list of objects
       with the keys `identifier`, `file`, and `line`.
 runs:
-  using: "node20"
+  using: "node24"
   main: "dist/index.js"


### PR DESCRIPTION
node20 is deprecated and will stop being supported soon. Our `.nvmrc`
was already on v24 anyway.
