### PR TITLE
Add ghc-9.12.3 binary

### DIFF
--- a/binaries.yaml
+++ b/binaries.yaml
@@ -16,6 +16,10 @@ oses:
     zip: '"C:\Program Files\7-Zip\7z.exe" a -tzip'
 
 ghcs:
+  ghc-9.12.3:
+    target: weeder-2.10.0
+    resolver: nightly-2026-01-15
+    extra-deps: ""
   ghc-9.10.3:
     target: weeder-2.10.0
     resolver: lts-24.13


### PR DESCRIPTION
<details>
<summary>

## AI Slop

</summary>

Adds a `ghc-9.12.3` entry so weeder-action can serve binaries for projects
using GHC 9.12.3 (no Stackage LTS covers this GHC exactly, but
`nightly-2026-01-15` does, and `weeder-2.10.0` builds against it with no
extra-deps needed -- verified locally).

</details>